### PR TITLE
Add calculate/liquidity API endpoints

### DIFF
--- a/web/app_highcharts.js
+++ b/web/app_highcharts.js
@@ -19,6 +19,10 @@ document.addEventListener('DOMContentLoaded', async function() {
     debugLog('Highcharts version: ' + Highcharts.version);
     
     // Initialize dashboard
+    document.getElementById('calcBtn').addEventListener('click', runCalculate);
+    document.getElementById('liqBtn').addEventListener('click', runLiquidity);
+    document.getElementById('stratBtn').addEventListener('click', runStrategies);
+
     await initializeDashboard();
 });
 
@@ -247,6 +251,45 @@ function showLoading(show) {
         overlay.classList.add('show');
     } else {
         overlay.classList.remove('show');
+    }
+}
+
+async function runCalculate() {
+    showLoading(true);
+    try {
+        const res = await fetch('/api/calculate', { method: 'POST' });
+        const data = await res.json();
+        debugLog('Calculate: ' + data.status);
+    } catch (err) {
+        debugLog('Calculate error: ' + err.message);
+    } finally {
+        showLoading(false);
+    }
+}
+
+async function runLiquidity() {
+    showLoading(true);
+    try {
+        const res = await fetch('/api/liquidity', { method: 'POST' });
+        const data = await res.json();
+        debugLog('Liquidity: ' + data.status);
+    } catch (err) {
+        debugLog('Liquidity error: ' + err.message);
+    } finally {
+        showLoading(false);
+    }
+}
+
+async function runStrategies() {
+    showLoading(true);
+    try {
+        const res = await fetch('/api/strategies', { method: 'POST' });
+        const data = await res.json();
+        debugLog('Strategies: ' + data.status);
+    } catch (err) {
+        debugLog('Strategies error: ' + err.message);
+    } finally {
+        showLoading(false);
     }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,11 @@
                         <p class="subtitle">Iraqi Stock Exchange Analysis Dashboard</p>
                     </div>
                 </div>
+                <div class="header-controls">
+                    <button id="calcBtn" class="btn btn-primary">Run Indicators</button>
+                    <button id="liqBtn" class="btn btn-secondary">Run Liquidity</button>
+                    <button id="stratBtn" class="btn btn-primary">Run Strategies</button>
+                </div>
             </div>
         </header>
 


### PR DESCRIPTION
## Summary
- expose POST `/api/calculate` and `/api/liquidity` endpoints
- allow POST `/api/strategies` to trigger strategy processing
- add buttons in web UI to run these operations
- wire up JavaScript calls to the new API

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847d5d025a483268f9c0ea7c390af12