### PR TITLE
Add strategy config and web display of signals

### DIFF
--- a/strategy_config.json
+++ b/strategy_config.json
@@ -1,0 +1,38 @@
+{
+  "rsi": {
+    "strong_buy": 20,
+    "buy": 30,
+    "weak_buy": 40,
+    "weak_sell": 60,
+    "sell": 70,
+    "strong_sell": 80
+  },
+  "rsi2": {
+    "strong_buy": 15,
+    "buy": 25,
+    "weak_buy": 35,
+    "weak_sell": 65,
+    "sell": 75,
+    "strong_sell": 85
+  },
+  "cmf": {
+    "strong_buy": 0.2,
+    "buy": 0.1,
+    "weak_buy": 0.05,
+    "weak_sell": -0.05,
+    "sell": -0.1,
+    "strong_sell": -0.2
+  },
+  "obvroc": {
+    "strong_buy": 10,
+    "buy": 5,
+    "weak_buy": 2,
+    "weak_sell": -2,
+    "sell": -5,
+    "strong_sell": -10
+  },
+  "macd_hist": {
+    "strong": 0.1,
+    "buy": 0.05
+  }
+}

--- a/web/app_highcharts.js
+++ b/web/app_highcharts.js
@@ -93,6 +93,17 @@ async function selectTicker(event) {
     
     // Create chart using the exact pattern from the Highcharts sample
     await createChart(symbol);
+
+    // Fetch latest strategy signals
+    try {
+        const res = await fetch(`/api/ticker/${symbol}?type=strategies`);
+        if (res.ok) {
+            const data = await res.json();
+            renderStrategySignals(data.signals);
+        }
+    } catch (err) {
+        console.log('Strategy fetch error', err);
+    }
 }
 
 // Update selected ticker information
@@ -291,6 +302,20 @@ async function runStrategies() {
     } finally {
         showLoading(false);
     }
+}
+
+function renderStrategySignals(signals) {
+    const container = document.getElementById('strategyRecommendations');
+    if (!signals) {
+        container.innerHTML = '';
+        return;
+    }
+    let html = '<h4>Latest Signals</h4><ul>';
+    for (const [name, sig] of Object.entries(signals)) {
+        html += `<li>${name}: <strong>${sig}</strong></li>`;
+    }
+    html += '</ul>';
+    container.innerHTML = html;
 }
 
  

--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,7 @@
                     <button id="calcBtn" class="btn btn-primary">Run Indicators</button>
                     <button id="liqBtn" class="btn btn-secondary">Run Liquidity</button>
                     <button id="stratBtn" class="btn btn-primary">Run Strategies</button>
+                    <a href="strategies.html" class="btn btn-link">Strategy Testing</a>
                 </div>
             </div>
         </header>
@@ -61,6 +62,7 @@
                         <i class="dropdown-arrow">▼</i>
                     </div>
                     <div class="selected-ticker-info" id="selectedTickerInfo"></div>
+                    <div id="strategyRecommendations" class="strategy-recs"></div>
                 </div>
             </div>
 

--- a/web/strategies.html
+++ b/web/strategies.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Strategy Testing</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="dashboard">
+        <header class="header">
+            <div class="header-content">
+                <h2>Strategy Testing</h2>
+                <a href="index.html" class="btn btn-link">Dashboard</a>
+            </div>
+        </header>
+        <div class="main-content-simple">
+            <div>
+                <select id="strategyTicker"></select>
+                <select id="strategySelect"></select>
+            </div>
+            <div id="strategyResult"></div>
+        </div>
+    </div>
+    <script src="strategies.js"></script>
+</body>
+</html>

--- a/web/strategies.js
+++ b/web/strategies.js
@@ -1,0 +1,41 @@
+async function init() {
+    const tickRes = await fetch('/api/tickers');
+    const tickers = await tickRes.json();
+    const tSel = document.getElementById('strategyTicker');
+    tickers.forEach(t => {
+        const opt = document.createElement('option');
+        opt.value = t.symbol; opt.textContent = t.symbol;
+        tSel.appendChild(opt);
+    });
+    tSel.addEventListener('change', loadStrategies);
+}
+
+async function loadStrategies() {
+    const sym = document.getElementById('strategyTicker').value;
+    if (!sym) return;
+    const res = await fetch(`/api/ticker/${sym}?type=strategies&full=1`);
+    const data = await res.json();
+    const sSel = document.getElementById('strategySelect');
+    sSel.innerHTML = '';
+    const strategies = Object.keys(data.signals);
+    strategies.forEach(s => {
+        const opt = document.createElement('option');
+        opt.value = s; opt.textContent = s;
+        sSel.appendChild(opt);
+    });
+    sSel.onchange = () => displaySignal(data, sSel.value);
+    if (strategies.length) displaySignal(data, strategies[0]);
+}
+
+function displaySignal(data, strategy) {
+    const div = document.getElementById('strategyResult');
+    const history = data.history || [];
+    let html = `<h3>${strategy}</h3><ul>`;
+    history.forEach(row => {
+        html += `<li>${row.Date} : ${row[strategy.replace(/ /g,'')] || row[strategy]}</li>`;
+    });
+    html += '</ul>';
+    div.innerHTML = html;
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- load strategy thresholds from `strategy_config.json`
- adjust strategy calculations to use loaded config
- compute per-strategy signal statistics in `generateStrategySummary`
- implement alternative state processing
- expose latest strategy signals via API
- show latest signals on dashboard and link to new strategy testing page
- add simple strategy testing HTML/JS

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847d60066ec83269300773b4a68be51