### PR TITLE
Improve docs with package overview

### DIFF
--- a/CODE_STRUCTURE.md
+++ b/CODE_STRUCTURE.md
@@ -1,0 +1,28 @@
+# Code Structure Guide
+
+This document explains the overall layout of the Go code so that new contributors can quickly find the relevant packages.
+
+```
+ISX_Auto_Scrapper2/
+├── cmd/               # CLI entry points
+│   └── isx-scraper/   # main application
+├── internal/          # private application packages
+│   ├── common/        # shared utilities, configuration and types
+│   ├── scraper/       # web scraping logic
+│   ├── indicators/    # indicator calculations
+│   ├── liquidity/     # liquidity scoring
+│   ├── strategies/    # trading strategies and backtesting
+│   └── server/        # HTTP dashboard and API
+└── web/               # static assets served by the dashboard
+```
+
+Each subpackage only exposes a minimal API to keep dependencies clear.  The `cmd/isx-scraper` folder contains the Cobra-based CLI which wires everything together.
+
+- **common** – logging, configuration and data structures used across the project.
+- **scraper** – drives a headless browser via `chromedp` and produces `raw_*.csv` files along with detailed processing reports.
+- **indicators** – calculates technical indicators and writes both descriptive and numerical CSVs.
+- **liquidity** – derives enhanced liquidity scores from historical price data.
+- **strategies** – implements trading strategies and a small backtesting engine.
+- **server** – serves the interactive web dashboard and exposes a REST API.
+
+The static files under `web/` are embedded at runtime and include HTML, JavaScript and CSS for the dashboard.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The project attempts to mirror the feature set of the original Python notebook w
 ## Table of contents
 - [Getting started](#getting-started)
 - [Repository layout & file overview](#repository-layout--file-overview)
+- [Code structure guide](#code-structure-guide)
 - [High-level data flow](#high-level-data-flow)
 - [Contributing & future work](#contributing--future-work)
 
@@ -72,23 +73,28 @@ Below is a concise explanation of every first-class Go source file as well as th
 
 | file | purpose |
 |------|---------|
-| `main.go` | CLI entry point powered by `spf13/cobra`.  Parses the `--mode` flag and orchestrates the high-level workflow. |
-| `config.go` | Centralised immutable configuration (default URLs, driver paths, scraping time-outs, …).  Exposed through the global `AppConfig` instance. |
-| `logger.go` | Very small wrapper around the standard library `log` package that prints to console **and** appends to `stock_analysis.log`. |
-| `types.go` | All common data structures (price row, processing/timing reports, strategy results, …) with CSV tags for seamless serialisation via `gocarina/gocsv`. |
-| `utils.go` | Generic helpers for working with CSV ticker files (`LoadTickers`, `LoadTickersWithInfo`). |
-| `technical_indicators.go` | Pure-function implementations of every technical indicator used by the project (SMA, EMA, RSI, MACD, Stochastic, CMF, OBV, PSAR, ATR, rolling STD).  No I/O here. |
-| `data_fetcher.go` | The web-scraper.  Uses `chromedp` to drive Microsoft Edge, navigate through pagination, handle pop-ups, wait for AJAX calls and finally export the table into `raw_<TICKER>.csv`.  Generates a detailed `ProcessingReport` and `TimingReport` for every run. |
-| `indicators_calculator.go` | Heart of the analytics layer.  Reads `raw_*.csv`, calculates the full indicator set via `TechnicalIndicators`, detects cross-over events, attaches human readable descriptions, applies trading strategies and writes `indicators_<TICKER>.csv`. |
-| `numerical_indicators_calculator.go` | Thin wrapper around `IndicatorsCalculator` that performs the same maths but **skips** the textual descriptions to keep the resulting `Indicators2_<TICKER>.csv` files lighter. |
-| `liquidity_calculator.go` | Computes an **enhanced liquidity score** per ticker based on average volume, zero-volume days, intraday volatility and several other factors. Results are saved to `liquidity_scores.csv`. |
-| `file_manager.go` | Generates fully-embedded HTML reports: CSS, JavaScript and PNG logo are base64-encoded so the output can be viewed offline. Relies on Go's `html/template` to populate placeholders. |
-| `strategies.go` | Contains `Strategies` & `StrategyTester` helpers that rate indicator combinations, run back-tests or Monte-Carlo simulations and dump summaries as JSON / CSV. |
+| `cmd/isx-scraper/main.go` | Cobra-powered CLI entry point that orchestrates the different modes. |
+| `internal/common/config.go` | Central configuration values exposed via the global `AppConfig`. |
+| `internal/common/logger.go` | Thin logger printing to console **and** `stock_analysis.log`. |
+| `internal/common/types.go` | Shared data structures (prices, reports, strategies). |
+| `internal/common/utils.go` | Helpers for reading ticker lists from CSV. |
+| `internal/indicators/technical_indicators.go` | Pure implementations of SMA, EMA, RSI, MACD and other indicators. |
+| `internal/scraper/data_fetcher.go` | Headless scraper that generates `raw_<TICKER>.csv` plus processing reports. |
+| `internal/indicators/indicators_calculator.go` | Calculates indicators with descriptions and writes `indicators_<TICKER>.csv`. |
+| `internal/indicators/numerical_indicators_calculator.go` | Faster, description-free indicator calculations for `Indicators2_<TICKER>.csv`. |
+| `internal/liquidity/liquidity_calculator.go` | Computes enhanced liquidity scores stored in `liquidity_scores.csv`. |
+| `internal/strategies/strategies.go` | Trading strategies and a simple backtesting engine. |
+| `internal/server/web_server.go` | HTTP dashboard and REST API serving the static files in `web/`. |
+| `web/` | Static HTML/JS/CSS assets for the dashboard. |
 | `go.mod` / `go.sum` | Standard Go dependency manifests. |
-| `*.csv` in repository root | Example raw data, ticker master list and previously calculated indicator / liquidity outputs. |
-| `isx-auto-scraper.exe`, `isx-scraper.exe` | Pre-built windows binaries for convenience (may be stale). |
+| `*.csv` in repository root | Example raw data, ticker master list and previously calculated outputs. |
+| `isx-auto-scraper.exe`, `isx-scraper.exe` | Pre-built Windows binaries for convenience (may be stale). |
 
 > **Note**: The Go sources are now organised under `cmd/` and `internal/` following a conventional layout. Earlier versions kept everything in the root package.
+
+## Code structure guide
+
+For a visual overview of the packages see [CODE_STRUCTURE.md](CODE_STRUCTURE.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- update README repository layout section
- reference new code structure guide
- add CODE_STRUCTURE.md with an overview of packages

## Testing
- `go build ./cmd/isx-scraper`

------
https://chatgpt.com/codex/tasks/task_e_68493c3c292083268830e437f9f708b5