### PR TITLE
Fix fetch popup when Highcharts not loaded

### DIFF
--- a/web/app_highcharts.js
+++ b/web/app_highcharts.js
@@ -14,10 +14,9 @@ document.addEventListener('DOMContentLoaded', async function() {
     
     if (typeof Highcharts === 'undefined') {
         debugLog('ERROR: Highcharts not loaded');
-        return;
+    } else {
+        debugLog('Highcharts version: ' + Highcharts.version);
     }
-    
-    debugLog('Highcharts version: ' + Highcharts.version);
     
     // Initialize dashboard
     document.getElementById('fetchBtn').addEventListener('click', openFetchModal);


### PR DESCRIPTION
## Summary
- don't abort dashboard initialization if Highcharts isn't loaded

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_684952425d4c832681451b530662ef49