### PR TITLE
Add tab navigation to dashboard

### DIFF
--- a/web/app_highcharts.js
+++ b/web/app_highcharts.js
@@ -18,6 +18,13 @@ document.addEventListener('DOMContentLoaded', async function() {
         debugLog('Highcharts version: ' + Highcharts.version);
     }
     
+    // Tab navigation setup
+    document.querySelectorAll('.tab-button').forEach(btn => {
+        btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+    });
+
+    switchTab('dashboardTab');
+
     // Initialize dashboard
     document.getElementById('fetchBtn').addEventListener('click', openFetchModal);
     document.getElementById('refreshBtn').addEventListener('click', runRefresh);
@@ -413,6 +420,25 @@ function renderStrategySignals(signals) {
     }
     html += '</ul>';
     container.innerHTML = html;
+}
+
+// Switch active tab and toggle visibility
+function switchTab(tabId) {
+    document.querySelectorAll('.tab-button').forEach(btn => {
+        if (btn.dataset.tab === tabId) {
+            btn.classList.add('active');
+        } else {
+            btn.classList.remove('active');
+        }
+    });
+
+    document.querySelectorAll('.tab-content').forEach(content => {
+        if (content.id === tabId) {
+            content.classList.add('active');
+        } else {
+            content.classList.remove('active');
+        }
+    });
 }
 
  

--- a/web/index.html
+++ b/web/index.html
@@ -53,8 +53,16 @@
             </div>
         </header>
 
-        <!-- Main Content -->
-        <div class="main-content-simple">
+        <!-- Tab Navigation -->
+        <div class="tab-navigation">
+            <button class="tab-button" data-tab="dashboardTab">Dashboard</button>
+            <button class="tab-button" data-tab="strategiesTab">Strategies</button>
+            <button class="tab-button" data-tab="backtestTab">Backtest</button>
+        </div>
+
+        <!-- Dashboard Tab -->
+        <div id="dashboardTab" class="tab-content">
+            <div class="main-content-simple">
             <!-- Ticker Selector -->
             <div class="ticker-selector">
                 <div class="ticker-section">
@@ -80,6 +88,24 @@
                 <div class="main-chart-container" style="height: 650px; width: 100%; max-width: 100%;">
                     <div id="container" style="height: 100%; width: 100%;"></div>
                 </div>
+            </div>
+        </div>
+
+        <!-- Strategies Tab -->
+        <div id="strategiesTab" class="tab-content">
+            <div class="main-content-simple">
+                <div>
+                    <select id="strategyTicker"></select>
+                    <select id="strategySelect"></select>
+                </div>
+                <div id="strategyResult"></div>
+            </div>
+        </div>
+
+        <!-- Backtest Tab -->
+        <div id="backtestTab" class="tab-content">
+            <div class="main-content-simple">
+                <p>Backtest results will appear here.</p>
             </div>
         </div>
     </div>
@@ -108,5 +134,6 @@
 
     <!-- Application JavaScript -->
     <script src="app_highcharts.js"></script>
+    <script src="strategies.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement tab structure on the main dashboard
- add tab navigation buttons with styling
- load strategies tab content and create placeholders for backtest
- provide JS helpers to switch active tabs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68499283181c832683249224f9a36b6a